### PR TITLE
Fix/clone stream

### DIFF
--- a/src/SenseNet.BlobStorage.IntegrationTests/BlobStorageIntegrationTests.cs
+++ b/src/SenseNet.BlobStorage.IntegrationTests/BlobStorageIntegrationTests.cs
@@ -1058,6 +1058,22 @@ namespace SenseNet.BlobStorage.IntegrationTests
                 return reader.ReadToEnd();
         }
 
+        protected string GetStringFromBinary(BinaryData binaryData)
+        {
+            using (var stream = binaryData.GetStream())
+            using (IO.StreamReader sr = new IO.StreamReader(stream))
+                return sr.ReadToEnd();
+        }
+
+        protected Type GetUsedBlobProvider(File file)
+        {
+            file = Node.Load<File>(file.Id);
+            var bin = file.Binary;
+            var ctx = BlobStorageComponents.DataProvider.GetBlobStorageContext(bin.FileId, false, file.VersionId,
+                PropertyType.GetByName("Binary").Id);
+            return ctx.Provider.GetType();
+        }
+
         protected class SizeLimitSwindler : IDisposable
         {
             private readonly BlobStorageIntegrationTests _testClass;
@@ -1071,6 +1087,22 @@ namespace SenseNet.BlobStorage.IntegrationTests
             public void Dispose()
             {
                 _testClass.ConfigureMinimumSizeForFileStreamInBytes(_originalValue, out _);
+            }
+        }
+
+        protected class BlobProviderSwindler : IDisposable
+        {
+            private readonly string _originalValue;
+
+            public BlobProviderSwindler(Type cheat)
+            {
+                _originalValue = Configuration.BlobStorage.BlobProviderClassName;
+                Configuration.BlobStorage.BlobProviderClassName = cheat.FullName;
+                BlobStorageComponents.ProviderSelector = new BuiltInBlobProviderSelector();
+            }
+            public void Dispose()
+            {
+                Configuration.BlobStorage.BlobProviderClassName = _originalValue;
             }
         }
 

--- a/src/SenseNet.BlobStorage.IntegrationTests/BlobStorageIntegrationTests.cs
+++ b/src/SenseNet.BlobStorage.IntegrationTests/BlobStorageIntegrationTests.cs
@@ -53,6 +53,19 @@ namespace SenseNet.BlobStorage.IntegrationTests
                 proc.ExecuteNonQuery();
             }
         }
+        protected void HackFileRowFileStream(int fileId, byte[] bytes)
+        {
+            var sql = $"UPDATE Files SET FileStream = @FileStream WHERE FileId = {fileId}";
+            using (var proc = DataProvider.CreateDataProcedure(sql))
+            {
+                proc.CommandType = CommandType.Text;
+                var parameter = DataProvider.CreateParameter();
+                parameter.ParameterName = "@FileStream";
+                parameter.Value = bytes;
+                proc.Parameters.Add(parameter);
+                proc.ExecuteNonQuery();
+            }
+        }
 
         private string GetConnectionString(string databaseName = null)
         {

--- a/src/SenseNet.BlobStorage.IntegrationTests/BuiltInLocalDiskTests.cs
+++ b/src/SenseNet.BlobStorage.IntegrationTests/BuiltInLocalDiskTests.cs
@@ -1,7 +1,11 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SenseNet.BlobStorage.IntegrationTests.Implementations;
+using SenseNet.ContentRepository;
+using SenseNet.ContentRepository.Storage;
 using SenseNet.ContentRepository.Storage.Data.SqlClient;
+using SenseNet.ContentRepository.Storage.Schema;
+using SenseNet.ContentRepository.Storage.Security;
 
 namespace SenseNet.BlobStorage.IntegrationTests
 {
@@ -112,6 +116,41 @@ namespace SenseNet.BlobStorage.IntegrationTests
         public void Blob_BuiltInLocalDisk_16_DeleteBig()
         {
             TestCase16_DeleteBig();
+        }
+
+        [TestMethod]
+        public void Blob_BuiltInLocalDisk_Bug_EmptyFileStreamAndExternalRecord()
+        {
+            // Symptom: record in the Files table that contains external provider and empty
+            // FileStream value (0x instead of [null]) causes error: LoadBinaryCacheEntity of the 
+            // BlobMetadata provider reads this value that overrides the BlobProvider settings
+            // and the SnStream constructor instantiates a RepositoryStream with a zero length buffer.
+
+            using (new SystemAccount())
+            using (new SizeLimitSwindler(this, 10))
+            {
+                var testRoot = CreateTestRoot();
+
+                var file = new File(testRoot) { Name = "File1.file" };
+                file.Binary.SetStream(RepositoryTools.GetStreamFromString("Lorem ipsum dolor sit amet..."));
+                file.Save();
+                var fileId = file.Binary.FileId;
+                var versionId = file.VersionId;
+                HackFileRowFileStream(fileId, new byte[0]);
+                var dbFile = LoadDbFile(fileId);
+                Assert.IsNotNull(dbFile.BlobProvider);
+                Assert.IsNotNull(dbFile.BlobProviderData);
+                Assert.IsNotNull(dbFile.FileStream);
+                Assert.AreEqual(0, dbFile.FileStream.Length);
+
+                // action
+                var bcEentity =
+                    BlobStorageComponents.DataProvider.LoadBinaryCacheEntity(versionId,
+                        PropertyType.GetByName("Binary").Id);
+
+                // assert
+                Assert.IsNull(bcEentity.RawData);
+            }
         }
     }
 }

--- a/src/SenseNet.BlobStorage.IntegrationTests/BuiltInMigrationTests.cs
+++ b/src/SenseNet.BlobStorage.IntegrationTests/BuiltInMigrationTests.cs
@@ -4,9 +4,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SenseNet.BlobStorage.IntegrationTests.Implementations;
 using SenseNet.ContentRepository;
 using SenseNet.ContentRepository.Storage;
+using SenseNet.ContentRepository.Storage.Data;
 using SenseNet.ContentRepository.Storage.Data.SqlClient;
 using SenseNet.ContentRepository.Storage.Schema;
 using SenseNet.ContentRepository.Storage.Security;
+using SenseNet.MsSqlFsBlobProvider;
 using File = SenseNet.ContentRepository.File;
 
 namespace SenseNet.BlobStorage.IntegrationTests
@@ -84,6 +86,120 @@ namespace SenseNet.BlobStorage.IntegrationTests
                     MoveData(file);
 
                 Assert.AreEqual(typeof(LocalDiskBlobProvider), GetUsedBlobProvider(file));
+            }
+        }
+
+
+        [TestMethod]
+        public void Blob_Migration_Staging_BuiltInMeta_BuiltInToExternal()
+        {
+            using (new SystemAccount())
+            using (new SizeLimitSwindler(this, _bigSizeLimit))
+            {
+                var file = CreateFile(_text);
+                Assert.AreEqual(typeof(BuiltInBlobProvider), GetUsedBlobProvider(file));
+                string loadedText = null;
+                using (new BlobProviderSwindler(typeof(LocalDiskBlobProvider)))
+                using (new SizeLimitSwindler(this, _smallSizeLimit))
+                {
+                    file = Node.Load<File>(file.Id);
+                    Assert.IsNull(file.Binary.BlobProvider);
+                    Assert.IsNull(file.Binary.BlobProviderData);
+                    var fileIdBefore = file.Binary.FileId;
+
+                    var stream = file.Binary.GetStream();
+                    var snStream = stream as SnStream;
+                    Assert.IsNotNull(snStream);
+                    Assert.AreEqual(typeof(BuiltInBlobProvider).Name, snStream.Context.Provider.GetType().Name);
+
+                    // action
+                    file.Binary.SetStream(stream);
+                    file.Save();
+
+                    // assert
+                    file = Node.Load<File>(file.Id);
+                    loadedText = GetStringFromBinary(file.Binary);
+
+                    Assert.AreEqual(typeof(LocalDiskBlobProvider).FullName, file.Binary.BlobProvider);
+                    Assert.AreEqual(fileIdBefore + 1, file.Binary.FileId);
+                }
+
+                Assert.AreEqual(_text, loadedText);
+            }
+        }
+        [TestMethod]
+        public void Blob_Migration_Staging_BuiltInMeta_SqlFsToExternal()
+        {
+            Assert.Inconclusive("Invalid test: built-in metadata provider cannot use the SqlFileStreamBlobProvider.");
+            using (new SystemAccount())
+            using (new BlobProviderSwindler(typeof(SqlFileStreamBlobProvider)))
+            using (new SizeLimitSwindler(this, _smallSizeLimit))
+            {
+                var file = CreateFile(_text);
+                Assert.AreEqual(typeof(SqlFileStreamBlobProvider), GetUsedBlobProvider(file));
+                string loadedText = null;
+                using (new BlobProviderSwindler(typeof(LocalDiskBlobProvider)))
+                {
+                    file = Node.Load<File>(file.Id);
+                    Assert.IsNull(file.Binary.BlobProvider);
+                    Assert.IsNull(file.Binary.BlobProviderData);
+                    var fileIdBefore = file.Binary.FileId;
+
+                    var stream = file.Binary.GetStream();
+                    var snStream = stream as SnStream;
+                    Assert.IsNotNull(snStream);
+                    Assert.AreEqual(typeof(SqlFileStreamBlobProvider).Name, snStream.Context.Provider.GetType().Name);
+
+                    // action
+                    file.Binary.SetStream(stream);
+                    file.Save();
+
+                    // assert
+                    file = Node.Load<File>(file.Id);
+                    loadedText = GetStringFromBinary(file.Binary);
+
+                    Assert.AreEqual(typeof(LocalDiskBlobProvider).FullName, file.Binary.BlobProvider);
+                    Assert.AreEqual(fileIdBefore + 1, file.Binary.FileId);
+                }
+
+                Assert.AreEqual(_text, loadedText);
+            }
+        }
+        [TestMethod]
+        public void Blob_Migration_Staging_BuiltInMeta_ExternalToExternal()
+        {
+            using (new SystemAccount())
+            using (new BlobProviderSwindler(typeof(LocalDiskBlobProvider)))
+            using (new SizeLimitSwindler(this, _smallSizeLimit))
+            {
+                var file = CreateFile(_text);
+                Assert.AreEqual(typeof(LocalDiskBlobProvider), GetUsedBlobProvider(file));
+                string loadedText = null;
+                using (new BlobProviderSwindler(typeof(LocalDiskChunkBlobProvider)))
+                {
+                    file = Node.Load<File>(file.Id);
+                    Assert.AreEqual(typeof(LocalDiskBlobProvider).FullName, file.Binary.BlobProvider);
+                    Assert.IsNotNull(file.Binary.BlobProviderData);
+                    var fileIdBefore = file.Binary.FileId;
+
+                    var stream = file.Binary.GetStream();
+                    var snStream = stream as SnStream;
+                    Assert.IsNotNull(snStream);
+                    Assert.AreEqual(typeof(LocalDiskBlobProvider).Name, snStream.Context.Provider.GetType().Name);
+
+                    // action
+                    file.Binary.SetStream(stream);
+                    file.Save();
+
+                    // assert
+                    file = Node.Load<File>(file.Id);
+                    loadedText = GetStringFromBinary(file.Binary);
+
+                    Assert.AreEqual(typeof(LocalDiskChunkBlobProvider).FullName, file.Binary.BlobProvider);
+                    Assert.AreEqual(fileIdBefore + 1, file.Binary.FileId);
+                }
+
+                Assert.AreEqual(_text, loadedText);
             }
         }
 

--- a/src/SenseNet.BlobStorage.IntegrationTests/BuiltInMigrationTests.cs
+++ b/src/SenseNet.BlobStorage.IntegrationTests/BuiltInMigrationTests.cs
@@ -128,44 +128,6 @@ namespace SenseNet.BlobStorage.IntegrationTests
             }
         }
         [TestMethod]
-        public void Blob_Migration_Staging_BuiltInMeta_SqlFsToExternal()
-        {
-            Assert.Inconclusive("Invalid test: built-in metadata provider cannot use the SqlFileStreamBlobProvider.");
-            using (new SystemAccount())
-            using (new BlobProviderSwindler(typeof(SqlFileStreamBlobProvider)))
-            using (new SizeLimitSwindler(this, _smallSizeLimit))
-            {
-                var file = CreateFile(_text);
-                Assert.AreEqual(typeof(SqlFileStreamBlobProvider), GetUsedBlobProvider(file));
-                string loadedText = null;
-                using (new BlobProviderSwindler(typeof(LocalDiskBlobProvider)))
-                {
-                    file = Node.Load<File>(file.Id);
-                    Assert.IsNull(file.Binary.BlobProvider);
-                    Assert.IsNull(file.Binary.BlobProviderData);
-                    var fileIdBefore = file.Binary.FileId;
-
-                    var stream = file.Binary.GetStream();
-                    var snStream = stream as SnStream;
-                    Assert.IsNotNull(snStream);
-                    Assert.AreEqual(typeof(SqlFileStreamBlobProvider).Name, snStream.Context.Provider.GetType().Name);
-
-                    // action
-                    file.Binary.SetStream(stream);
-                    file.Save();
-
-                    // assert
-                    file = Node.Load<File>(file.Id);
-                    loadedText = GetStringFromBinary(file.Binary);
-
-                    Assert.AreEqual(typeof(LocalDiskBlobProvider).FullName, file.Binary.BlobProvider);
-                    Assert.AreEqual(fileIdBefore + 1, file.Binary.FileId);
-                }
-
-                Assert.AreEqual(_text, loadedText);
-            }
-        }
-        [TestMethod]
         public void Blob_Migration_Staging_BuiltInMeta_ExternalToExternal()
         {
             using (new SystemAccount())


### PR DESCRIPTION
Please check the changes.
- New test methods to check the right usage of the BinaryCacheEntity when the used blob provider is external.
- New test methods to check the right UpdateBinary algorithm in various constellations.

These changes are connected to other modifications of the following repositories:
- **sensenet**: https://github.com/SenseNet/sensenet/tree/fix/clone-stream
- **sn-blob-mssqlfs**: https://github.com/SenseNet/sn-blob-mssqlfs/tree/fix/clone-stream