### PR TITLE
Upgrade PackagingMsSqlTests.

### DIFF
--- a/src/SenseNet.IntegrationTests.Common/Implementations/MsSqlTools.cs
+++ b/src/SenseNet.IntegrationTests.Common/Implementations/MsSqlTools.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using SenseNet.ContentRepository.Storage.Data.MsSqlClient;
+
+namespace SenseNet.IntegrationTests.Common.Implementations
+{
+    public class MsSqlTools
+    {
+        public static void ExecuteNonQuery(string sql, string connectionString = null)
+        {
+            ExecuteNonQueryAsync(sql, connectionString).ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+        public static async Task ExecuteNonQueryAsync(string sql, string connectionString = null,
+            CancellationToken cancellationToken = default)
+        {
+            Configuration.ConnectionStrings.ConnectionString = SenseNet.IntegrationTests.Common.ConnectionStrings.ForPackagingTests;
+            using (var ctx = new MsSqlDataContext(cancellationToken))
+            {
+                await ctx.ExecuteNonQueryAsync(sql).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/SenseNet.IntegrationTests.Common/Implementations/SqlTestingDataProvider.cs
+++ b/src/SenseNet.IntegrationTests.Common/Implementations/SqlTestingDataProvider.cs
@@ -1,108 +1,112 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using Newtonsoft.Json;
-using SenseNet.ContentRepository.Storage.Data;
-using SenseNet.ContentRepository.Storage.Data.SqlClient;
-using SenseNet.Diagnostics;
-using SenseNet.Tests.Implementations;
+﻿//using System;
+//using System.Collections.Generic;
+//using System.Data;
+//using Newtonsoft.Json;
+//using SenseNet.ContentRepository.Storage.Data;
+//using SenseNet.ContentRepository.Storage.Data.SqlClient;
+//using SenseNet.Diagnostics;
+//using SenseNet.Tests.Implementations;
 
-namespace SenseNet.IntegrationTests.Common.Implementations
-{
-    public class SqlTestingDataProvider : ITestingDataProviderExtension
-    {
-        public DataProvider MainProvider { get; set; }
-        public void InitializeForTests()
-        {
-            using (var proc = DataProvider.Instance.CreateDataProcedure(@"
-ALTER TABLE [BinaryProperties] CHECK CONSTRAINT ALL
-ALTER TABLE [FlatProperties] CHECK CONSTRAINT ALL
-ALTER TABLE [Nodes] CHECK CONSTRAINT ALL
-ALTER TABLE [ReferenceProperties] CHECK CONSTRAINT ALL
-ALTER TABLE [TextPropertiesNText] CHECK CONSTRAINT ALL
-ALTER TABLE [TextPropertiesNVarchar] CHECK CONSTRAINT ALL
-ALTER TABLE [Versions] CHECK CONSTRAINT ALL
-"))
-            {
-                proc.CommandType = CommandType.Text;
-                proc.ExecuteNonQuery();
-            }
-        }
+//namespace SenseNet.IntegrationTests.Common.Implementations
+//{
+//    public class SqlTestingDataProvider : ITestingDataProviderExtension
+//    {
 
-        public string GetSecurityControlStringForTests()
-        {
-            var securityEntitiesArray = new List<object>();
-            using (var cmd = new SqlProcedure { CommandText = "SELECT NodeId, ParentNodeId, [OwnerId] FROM Nodes ORDER BY NodeId", CommandType = CommandType.Text })
-            {
-                using (var reader = cmd.ExecuteReader())
-                {
-                    int count = 0;
-                    while (reader.Read())
-                    {
-                        securityEntitiesArray.Add(new
-                        {
-                            NodeId = reader.GetSafeInt32(0),
-                            ParentId = reader.GetSafeInt32(1),
-                            OwnerId = reader.GetSafeInt32(2),
-                        });
+//        // Use DataStore.DataProvider instead of DataProvider.Instance
+//        // Use and extend MsSqlTools
 
-                        count++;
-                        // it is neccessary to examine the number of Nodes, because loading a too big security structure may require too much resource
-                        if (count > 200000)
-                            throw new ArgumentOutOfRangeException("number of Nodes");
-                    }
-                }
-            }
-            return JsonConvert.SerializeObject(securityEntitiesArray);
-        }
+//        public DataProvider MainProvider { get; set; }
+//        public void InitializeForTests()
+//        {
+//            using (var proc = DataProvider.Instance.CreateDataProcedure(@"
+//ALTER TABLE [BinaryProperties] CHECK CONSTRAINT ALL
+//ALTER TABLE [FlatProperties] CHECK CONSTRAINT ALL
+//ALTER TABLE [Nodes] CHECK CONSTRAINT ALL
+//ALTER TABLE [ReferenceProperties] CHECK CONSTRAINT ALL
+//ALTER TABLE [TextPropertiesNText] CHECK CONSTRAINT ALL
+//ALTER TABLE [TextPropertiesNVarchar] CHECK CONSTRAINT ALL
+//ALTER TABLE [Versions] CHECK CONSTRAINT ALL
+//"))
+//            {
+//                proc.CommandType = CommandType.Text;
+//                proc.ExecuteNonQuery();
+//            }
+//        }
 
-        public int GetPermissionLogEntriesCountAfterMoment(DateTime moment)
-        {
-            var count = 0;
-            var sql =
-                $"SELECT COUNT(1) FROM LogEntries WHERE Title = 'PermissionChanged' AND LogDate>='{moment.ToString("yyyy-MM-dd HH:mm:ss")}'";
-            var proc = DataProvider.Instance.CreateDataProcedure(sql);
-            proc.CommandType = System.Data.CommandType.Text;
-            using (var reader = proc.ExecuteReader())
-            {
-                while (reader.Read())
-                {
-                    count = reader.GetSafeInt32(0);
-                }
-            }
-            return count;
-        }
+//        public string GetSecurityControlStringForTests()
+//        {
+//            var securityEntitiesArray = new List<object>();
+//            using (var cmd = new SqlProcedure { CommandText = "SELECT NodeId, ParentNodeId, [OwnerId] FROM Nodes ORDER BY NodeId", CommandType = CommandType.Text })
+//            {
+//                using (var reader = cmd.ExecuteReader())
+//                {
+//                    int count = 0;
+//                    while (reader.Read())
+//                    {
+//                        securityEntitiesArray.Add(new
+//                        {
+//                            NodeId = reader.GetSafeInt32(0),
+//                            ParentId = reader.GetSafeInt32(1),
+//                            OwnerId = reader.GetSafeInt32(2),
+//                        });
 
-        public AuditLogEntry[] LoadLastAuditLogEntries(int count)
-        {
-            throw new NotImplementedException();
-        }
+//                        count++;
+//                        // it is neccessary to examine the number of Nodes, because loading a too big security structure may require too much resource
+//                        if (count > 200000)
+//                            throw new ArgumentOutOfRangeException("number of Nodes");
+//                    }
+//                }
+//            }
+//            return JsonConvert.SerializeObject(securityEntitiesArray);
+//        }
 
-        public void CheckScript(string commandText)
-        {
-            // c:\Program Files\Microsoft SQL Server\90\SDK\Assemblies\Microsoft.SqlServer.Smo.dll
-            // c:\Program Files\Microsoft SQL Server\90\SDK\Assemblies\Microsoft.SqlServer.ConnectionInfo.dll
+//        public int GetPermissionLogEntriesCountAfterMoment(DateTime moment)
+//        {
+//            var count = 0;
+//            var sql =
+//                $"SELECT COUNT(1) FROM LogEntries WHERE Title = 'PermissionChanged' AND LogDate>='{moment.ToString("yyyy-MM-dd HH:mm:ss")}'";
+//            var proc = DataProvider.Instance.CreateDataProcedure(sql);
+//            proc.CommandType = System.Data.CommandType.Text;
+//            using (var reader = proc.ExecuteReader())
+//            {
+//                while (reader.Read())
+//                {
+//                    count = reader.GetSafeInt32(0);
+//                }
+//            }
+//            return count;
+//        }
 
-            // The code maybe equivalent to this script:
-            // SET NOEXEC ON
-            // GO
-            // SELECT * FROM Nodes
-            // GO
-            // SET NOEXEC OFF
-            // GO
+//        public AuditLogEntry[] LoadLastAuditLogEntries(int count)
+//        {
+//            throw new NotImplementedException();
+//        }
 
-            throw new NotImplementedException();
-        }
+//        public void CheckScript(string commandText)
+//        {
+//            // c:\Program Files\Microsoft SQL Server\90\SDK\Assemblies\Microsoft.SqlServer.Smo.dll
+//            // c:\Program Files\Microsoft SQL Server\90\SDK\Assemblies\Microsoft.SqlServer.ConnectionInfo.dll
 
-        public IEnumerable<IndexIntegrityCheckerItem> GetTimestampDataForOneNodeIntegrityCheck(string path, int[] excludedNodeTypeIds)
-        {
-            throw new NotImplementedException();
-        }
+//            // The code maybe equivalent to this script:
+//            // SET NOEXEC ON
+//            // GO
+//            // SELECT * FROM Nodes
+//            // GO
+//            // SET NOEXEC OFF
+//            // GO
 
-        public IEnumerable<IndexIntegrityCheckerItem> GetTimestampDataForRecursiveIntegrityCheck(string path, int[] excludedNodeTypeIds)
-        {
-            throw new NotImplementedException();
-        }
+//            throw new NotImplementedException();
+//        }
 
-    }
-}
+//        public IEnumerable<IndexIntegrityCheckerItem> GetTimestampDataForOneNodeIntegrityCheck(string path, int[] excludedNodeTypeIds)
+//        {
+//            throw new NotImplementedException();
+//        }
+
+//        public IEnumerable<IndexIntegrityCheckerItem> GetTimestampDataForRecursiveIntegrityCheck(string path, int[] excludedNodeTypeIds)
+//        {
+//            throw new NotImplementedException();
+//        }
+
+//    }
+//}

--- a/src/SenseNet.IntegrationTests.Common/SenseNet.IntegrationTests.Common.csproj
+++ b/src/SenseNet.IntegrationTests.Common/SenseNet.IntegrationTests.Common.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConnectionStrings.cs" />
+    <Compile Include="Implementations\MsSqlTools.cs" />
     <Compile Include="Implementations\SqlTestingDataProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/SenseNet.Packaging.IntegrationTests/PackagingMsSqlTests.cs
+++ b/src/SenseNet.Packaging.IntegrationTests/PackagingMsSqlTests.cs
@@ -11,9 +11,14 @@ using SenseNet.Packaging.Steps;
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Threading;
+using SenseNet.ContentRepository.Storage.Data.MsSqlClient;
 using SenseNet.ContentRepository.Storage.Data.SqlClient;
+using SenseNet.Extensions.DependencyInjection;
+using SenseNet.IntegrationTests.Common.Implementations;
 using SenseNet.Packaging.IntegrationTests.Implementations;
 using SenseNet.Tests;
+using Task = System.Threading.Tasks.Task;
 
 namespace SenseNet.Packaging.IntegrationTests
 {
@@ -72,16 +77,12 @@ CREATE TABLE [dbo].[Packages](
 
             // build database
             var builder = new RepositoryBuilder();
-            builder.UsePackagingDataProviderExtension(new SqlPackagingDataProvider());
+            builder.UsePackagingDataProviderExtension(new MsSqlPackagingDataProvider());
 
             // preparing database
-            ConnectionStrings.ConnectionString = SenseNet.IntegrationTests.Common.ConnectionStrings.ForPackagingTests;
-            var proc = DataProvider.Instance.CreateDataProcedure("DELETE FROM [Packages]");
-            proc.CommandType = CommandType.Text;
-            proc.ExecuteNonQuery();
-            proc = DataProvider.Instance.CreateDataProcedure("DBCC CHECKIDENT ('[Packages]', RESEED, 1)");
-            proc.CommandType = CommandType.Text;
-            proc.ExecuteNonQuery();
+            var cnstr = SenseNet.IntegrationTests.Common.ConnectionStrings.ForPackagingTests;
+            MsSqlTools.ExecuteNonQuery("DELETE FROM [Packages]", cnstr);
+            MsSqlTools.ExecuteNonQuery("DBCC CHECKIDENT ('[Packages]', RESEED, 1)", cnstr);
 
             RepositoryVersionInfo.Reset();
         }
@@ -105,9 +106,7 @@ CREATE TABLE [dbo].[Packages](
                             <Dependencies>
                                 <Dependency id='Component1' version='7.0' />
                             </Dependencies>
-                            <Steps>
-                                <Trace>Package is running.</Trace>
-                            </Steps>
+                            <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                         </Package>");
                 Assert.Fail("PackagingException was not thrown.");
             }
@@ -127,9 +126,7 @@ CREATE TABLE [dbo].[Packages](
                         <Id>MyCompany.MyComponent</Id>
                         <ReleaseDate>2017-01-01</ReleaseDate>
                         <Version>1.0</Version>
-                        <Steps>
-                            <Trace>Package is running.</Trace>
-                        </Steps>
+                        <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                     </Package>");
 
             // action
@@ -140,9 +137,7 @@ CREATE TABLE [dbo].[Packages](
                             <Id>MyCompany.MyComponent</Id>
                             <ReleaseDate>2017-01-01</ReleaseDate>
                             <Version>1.1</Version>
-                            <Steps>
-                                <Trace>Package is running.</Trace>
-                            </Steps>
+                            <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                         </Package>");
                 Assert.Fail("PackagingException was not thrown.");
             }
@@ -161,9 +156,7 @@ CREATE TABLE [dbo].[Packages](
                         <Id>Component2</Id>
                         <ReleaseDate>2017-01-01</ReleaseDate>
                         <Version>1.1</Version>
-                        <Steps>
-                            <Trace>Package is running.</Trace>
-                        </Steps>
+                        <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                     </Package>");
                 Assert.Fail("PackagingException was not thrown.");
             }
@@ -180,9 +173,7 @@ CREATE TABLE [dbo].[Packages](
                         <Id>MyCompany.MyComponent</Id>
                         <ReleaseDate>2017-01-01</ReleaseDate>
                         <Version>1.0</Version>
-                        <Steps>
-                            <Trace>Package is running.</Trace>
-                        </Steps>
+                        <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                     </Package>");
 
             // action
@@ -193,9 +184,7 @@ CREATE TABLE [dbo].[Packages](
                             <Id>MyCompany.MyComponent</Id>
                             <ReleaseDate>2017-01-01</ReleaseDate>
                             <Version>1.0</Version>
-                            <Steps>
-                                <Trace>Package is running.</Trace>
-                            </Steps>
+                            <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                         </Package>");
                 Assert.Fail("PackagingException was not thrown.");
             }
@@ -213,9 +202,7 @@ CREATE TABLE [dbo].[Packages](
                         <Id>Component1</Id>
                         <ReleaseDate>2017-01-01</ReleaseDate>
                         <Version>1.0</Version>
-                        <Steps>
-                            <Trace>Package is running.</Trace>
-                        </Steps>
+                        <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                     </Package>");
 
             // action
@@ -229,9 +216,7 @@ CREATE TABLE [dbo].[Packages](
                             <Dependencies>
                                 <Dependency id='Component1' version='1.2' />
                             </Dependencies>
-                            <Steps>
-                                <Trace>Package is running.</Trace>
-                            </Steps>
+                            <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                         </Package>");
                 Assert.Fail("PackagingException was not thrown.");
             }
@@ -248,9 +233,7 @@ CREATE TABLE [dbo].[Packages](
                         <Id>Component1</Id>
                         <ReleaseDate>2017-01-01</ReleaseDate>
                         <Version>1.0</Version>
-                        <Steps>
-                            <Trace>Package is running.</Trace>
-                        </Steps>
+                        <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                     </Package>");
 
             // action
@@ -264,9 +247,7 @@ CREATE TABLE [dbo].[Packages](
                             <Dependencies>
                                 <Dependency id='Component1' minVersion='1.1' />
                             </Dependencies>
-                            <Steps>
-                                <Trace>Package is running.</Trace>
-                            </Steps>
+                            <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                         </Package>");
                 Assert.Fail("PackagingException was not thrown.");
             }
@@ -283,9 +264,7 @@ CREATE TABLE [dbo].[Packages](
                         <Id>Component1</Id>
                         <ReleaseDate>2017-01-01</ReleaseDate>
                         <Version>3.0</Version>
-                        <Steps>
-                            <Trace>Package is running.</Trace>
-                        </Steps>
+                        <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                     </Package>");
 
             // action
@@ -299,9 +278,7 @@ CREATE TABLE [dbo].[Packages](
                             <Dependencies>
                                 <Dependency id='Component1' maxVersion='2.0' />
                             </Dependencies>
-                            <Steps>
-                                <Trace>Package is running.</Trace>
-                            </Steps>
+                            <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                         </Package>");
                 Assert.Fail("PackagingException was not thrown.");
             }
@@ -318,9 +295,7 @@ CREATE TABLE [dbo].[Packages](
                         <Id>Component1</Id>
                         <ReleaseDate>2017-01-01</ReleaseDate>
                         <Version>1.0</Version>
-                        <Steps>
-                            <Trace>Package is running.</Trace>
-                        </Steps>
+                        <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                     </Package>");
 
             // action
@@ -334,9 +309,7 @@ CREATE TABLE [dbo].[Packages](
                             <Dependencies>
                                 <Dependency id='Component1' minVersionExclusive='1.0' />
                             </Dependencies>
-                            <Steps>
-                                <Trace>Package is running.</Trace>
-                            </Steps>
+                            <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                         </Package>");
                 Assert.Fail("PackagingException was not thrown.");
             }
@@ -353,9 +326,7 @@ CREATE TABLE [dbo].[Packages](
                         <Id>Component1</Id>
                         <ReleaseDate>2017-01-01</ReleaseDate>
                         <Version>3.0</Version>
-                        <Steps>
-                            <Trace>Package is running.</Trace>
-                        </Steps>
+                        <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                     </Package>");
 
             // action
@@ -369,9 +340,7 @@ CREATE TABLE [dbo].[Packages](
                             <Dependencies>
                                 <Dependency id='Component1' maxVersionExclusive='2.0' />
                             </Dependencies>
-                            <Steps>
-                                <Trace>Package is running.</Trace>
-                            </Steps>
+                            <!--<Steps><Trace>Package is running.</Trace></Steps>-->
                         </Package>");
                 Assert.Fail("PackagingException was not thrown.");
             }
@@ -465,9 +434,8 @@ CREATE TABLE [dbo].[Packages](
             var component = RepositoryVersionInfo.Instance.Components.FirstOrDefault();
             Assert.IsNotNull(component);
             Assert.AreEqual("Component42", component.ComponentId);
+            Assert.IsNotNull(component.Version);
             Assert.AreEqual("4.42", component.Version.ToString());
-            Assert.IsNotNull(component.AcceptableVersion);
-            Assert.AreEqual("4.42", component.AcceptableVersion.ToString());
             var pkg = RepositoryVersionInfo.Instance.InstalledPackages.FirstOrDefault();
             Assert.IsNotNull(pkg);
             Assert.AreEqual("Component42", pkg.ComponentId);
@@ -526,9 +494,8 @@ CREATE TABLE [dbo].[Packages](
             var component = RepositoryVersionInfo.Instance.Components.FirstOrDefault();
             Assert.IsNotNull(component);
             Assert.AreEqual("Component42", component.ComponentId);
+            Assert.IsNotNull(component.Version);
             Assert.AreEqual("4.42", component.Version.ToString());
-            Assert.IsNotNull(component.AcceptableVersion);
-            Assert.AreEqual("4.42", component.AcceptableVersion.ToString());
             pkg = RepositoryVersionInfo.Instance.InstalledPackages.FirstOrDefault();
             Assert.IsNotNull(pkg);
             Assert.AreEqual("Component42", pkg.ComponentId);
@@ -573,9 +540,8 @@ CREATE TABLE [dbo].[Packages](
             var component = RepositoryVersionInfo.Instance.Components.FirstOrDefault();
             Assert.IsNotNull(component);
             Assert.AreEqual("MyCompany.MyComponent", component.ComponentId);
-            Assert.AreEqual("1.2", component.Version.ToString());
-            Assert.IsNotNull(component.AcceptableVersion);
-            Assert.AreEqual("1.0", component.AcceptableVersion.ToString());
+            Assert.IsNotNull(component.Version);
+            Assert.AreEqual("1.0", component.Version.ToString());
             var pkg = RepositoryVersionInfo.Instance.InstalledPackages.LastOrDefault();
             Assert.IsNotNull(pkg);
             Assert.AreEqual("MyCompany.MyComponent", pkg.ComponentId);
@@ -590,9 +556,8 @@ CREATE TABLE [dbo].[Packages](
             component = RepositoryVersionInfo.Instance.Components.FirstOrDefault();
             Assert.IsNotNull(component);
             Assert.AreEqual("MyCompany.MyComponent", component.ComponentId);
-            Assert.AreEqual("1.2", component.Version.ToString());
-            Assert.IsNotNull(component.AcceptableVersion);
-            Assert.AreEqual("1.0", component.AcceptableVersion.ToString());
+            Assert.IsNotNull(component.Version);
+            Assert.AreEqual("1.0", component.Version.ToString());
             pkg = RepositoryVersionInfo.Instance.InstalledPackages.LastOrDefault();
             Assert.IsNotNull(pkg);
             Assert.AreEqual("MyCompany.MyComponent", pkg.ComponentId);
@@ -607,9 +572,8 @@ CREATE TABLE [dbo].[Packages](
             component = RepositoryVersionInfo.Instance.Components.FirstOrDefault();
             Assert.IsNotNull(component);
             Assert.AreEqual("MyCompany.MyComponent", component.ComponentId);
+            Assert.IsNotNull(component.Version);
             Assert.AreEqual("1.2", component.Version.ToString());
-            Assert.IsNotNull(component.AcceptableVersion);
-            Assert.AreEqual("1.2", component.AcceptableVersion.ToString());
             pkg = RepositoryVersionInfo.Instance.InstalledPackages.LastOrDefault();
             Assert.IsNotNull(pkg);
             Assert.AreEqual("MyCompany.MyComponent", pkg.ComponentId);
@@ -659,9 +623,8 @@ CREATE TABLE [dbo].[Packages](
             var component = RepositoryVersionInfo.Instance.Components.FirstOrDefault();
             Assert.IsNotNull(component);
             Assert.AreEqual("MyCompany.MyComponent", component.ComponentId);
-            Assert.AreEqual("1.2", component.Version.ToString());
-            Assert.IsNotNull(component.AcceptableVersion);
-            Assert.AreEqual("1.0", component.AcceptableVersion.ToString());
+            Assert.IsNotNull(component.Version);
+            Assert.AreEqual("1.0", component.Version.ToString());
             var pkg = RepositoryVersionInfo.Instance.InstalledPackages.LastOrDefault();
             Assert.IsNotNull(pkg);
             Assert.AreEqual("MyCompany.MyComponent", pkg.ComponentId);
@@ -717,9 +680,8 @@ CREATE TABLE [dbo].[Packages](
             var component = RepositoryVersionInfo.Instance.Components.FirstOrDefault();
             Assert.IsNotNull(component);
             Assert.AreEqual("MyCompany.MyComponent", component.ComponentId);
+            Assert.IsNotNull(component.Version);
             Assert.AreEqual("1.2", component.Version.ToString());
-            Assert.IsNotNull(component.AcceptableVersion);
-            Assert.AreEqual("1.2", component.AcceptableVersion.ToString());
             var pkg = RepositoryVersionInfo.Instance.InstalledPackages.LastOrDefault();
             Assert.IsNotNull(pkg);
             Assert.AreEqual("MyCompany.MyComponent", pkg.ComponentId);
@@ -778,9 +740,8 @@ CREATE TABLE [dbo].[Packages](
             var component = RepositoryVersionInfo.Instance.Components.FirstOrDefault();
             Assert.IsNotNull(component);
             Assert.AreEqual("MyCompany.MyComponent", component.ComponentId);
+            Assert.IsNotNull(component.Version);
             Assert.AreEqual("1.2", component.Version.ToString());
-            Assert.IsNotNull(component.AcceptableVersion);
-            Assert.AreEqual("1.2", component.AcceptableVersion.ToString());
             var pkg = RepositoryVersionInfo.Instance.InstalledPackages.LastOrDefault();
             Assert.IsNotNull(pkg);
             Assert.AreEqual("MyCompany.MyComponent", pkg.ComponentId);
@@ -847,10 +808,10 @@ CREATE TABLE [dbo].[Packages](
             // check
             var actual = string.Join(" | ", verInfo.Components
                 .OrderBy(a => a.ComponentId)
-                .Select(a => $"{a.ComponentId}: {a.AcceptableVersion} ({a.Version})")
+                .Select(a => $"{a.ComponentId}: {a.Version} {a.Manifest}")
                 .ToArray());
             // 
-            var expected = "C1: 1.2 (1.2) | C2: 1.0 (1.2)";
+            var expected = "C1: 1.2 <Package type='Patch'/> | C2: 1.0 <Package type='Install'/>";
             Assert.AreEqual(expected, actual);
             Assert.AreEqual(9, verInfo.InstalledPackages.Count());
         }
@@ -871,11 +832,11 @@ CREATE TABLE [dbo].[Packages](
             // check
             var actual = string.Join(" | ", verInfo.Components
                 .OrderBy(a => a.ComponentId)
-                .Select(a => $"{a.ComponentId}: {a.AcceptableVersion} ({a.Version})")
+                .Select(a => $"{a.ComponentId}: {a.Version}")
                 .ToArray());
             
             // we expect a separate line for every Install package execution
-            var expected = "C1: 1.0 (1.2) | C1: 1.0 (1.2) | C1: 1.0 (1.2) | C2: 1.0 (1.0)";
+            var expected = "C1: 1.0 | C2: 1.0";
             Assert.AreEqual(expected, actual);
             Assert.AreEqual(6, verInfo.InstalledPackages.Count());
         }
@@ -910,7 +871,8 @@ CREATE TABLE [dbo].[Packages](
             Assert.IsNull(package?.Manifest);
 
             // load manifest explicitly
-            PackageManager.Storage.LoadManifest(package);
+            PackageManager.Storage.LoadManifestAsync(package, CancellationToken.None)
+                .ConfigureAwait(false).GetAwaiter().GetResult();
             var actual = package?.Manifest;
             Assert.AreEqual(expected, actual);
         }
@@ -936,7 +898,8 @@ CREATE TABLE [dbo].[Packages](
             var packs = RepositoryVersionInfo.Instance.InstalledPackages
                 .Where(p => p.ExecutionResult != ExecutionResult.Successful);
             foreach (var package in packs)
-                PackageManager.Storage.DeletePackage(package);
+                PackageManager.Storage.DeletePackageAsync(package, CancellationToken.None)
+                    .ConfigureAwait(false).GetAwaiter().GetResult();
             RepositoryVersionInfo.Reset();
 
             // check
@@ -955,7 +918,8 @@ CREATE TABLE [dbo].[Packages](
             SavePackage("C1", "1.2", "10:00", "2016-01-09", PackageType.Patch, ExecutionResult.Successful);
 
             // action
-            PackageManager.Storage.DeleteAllPackages();
+            PackageManager.Storage.DeleteAllPackagesAsync(CancellationToken.None)
+                .ConfigureAwait(false).GetAwaiter().GetResult();
 
             // check
             Assert.IsFalse(RepositoryVersionInfo.Instance.InstalledPackages.Any());
@@ -971,12 +935,18 @@ CREATE TABLE [dbo].[Packages](
         {
             ExecuteSqlCommand(InstallPackagesTableSql);
         }
+
         private static void ExecuteSqlCommand(string sql)
         {
+            ExecuteSqlCommandAsync(sql).ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+        private static async Task ExecuteSqlCommandAsync(string sql, CancellationToken cancellationToken = default)
+        {
             ConnectionStrings.ConnectionString = SenseNet.IntegrationTests.Common.ConnectionStrings.ForPackagingTests;
-            var proc = DataProvider.Instance.CreateDataProcedure(sql);
-            proc.CommandType = CommandType.Text;
-            proc.ExecuteNonQuery();
+            using (var ctx = new MsSqlDataContext(cancellationToken))
+            {
+                await ctx.ExecuteNonQueryAsync(sql).ConfigureAwait(false);
+            }
         }
 
         /*--------------------------------------------------------*/
@@ -995,7 +965,8 @@ CREATE TABLE [dbo].[Packages](
                 PackageType = packageType,
                 Manifest = $"<Package type='{packageType}'/>"
             };
-            PackageManager.Storage.SavePackage(package);
+            PackageManager.Storage.SavePackageAsync(package, CancellationToken.None)
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         internal static Manifest ParseManifestHead(string manifestXml)


### PR DESCRIPTION
The PR contains some upgrades to the modern data provider infrastructure. The **PackagingMsSqlTests** was the focus so the upgrade is partial because contains compiler errors. The relevant tests are executable if all projects are unloaded except  **SenseNet.IntegrationTests.Common** and **SenseNet.Packaging.IntegrationTests**. To run the relevant tests use the "Packaging" filter in the test explorer. The best available state is **17 passed** and **7 failed** tests. The passed tests helped the new **ComponentInfo** development.